### PR TITLE
Uso inadequado de pip.main() causa conflito na versão LTD do QGIS para Linux

### DIFF
--- a/algorithms/layersFromPDF.py
+++ b/algorithms/layersFromPDF.py
@@ -49,14 +49,15 @@ from qgis import processing
 from qgis.PyQt.QtGui import QIcon
 from GeoINCRA.images.Imgs import *
 import os, re
-import pip
+import subprocess
+import sys
+
 try:
     from PyPDF2 import PdfReader
 except ImportError:
     print('PyPDF2 não está instalado. Tentando instalar "PyPDF2" utilizando "pip"...')
     try:
-        # Executa o pip usando subprocess
-        pip.main(["install","PyPDF2"])
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "PyPDF2"])
         from PyPDF2 import PdfReader
     except Exception as e:
         print(f"Houve um erro ao tentar instalar o PyPDF2: {e}")


### PR DESCRIPTION
Essa parte do código conflita com a versão LTD do QGIS para Linux.


https://github.com/OpenGeoOne/GeoINCRA/blob/ab46fb0aee28631b75ae78f50d4280bb3fdf4c7e/algorithms/layersFromPDF.py#L52-L62

De modo geral "não se deve" fazer isso, uma alternativa _pythonica_ seria:

```py
import subprocess
import sys

try:
    from PyPDF2 import PdfReader
except ImportError:
    print('PyPDF2 não está instalado. Tentando instalar "PyPDF2" utilizando "pip"...')
    try:
        subprocess.check_call([sys.executable, "-m", "pip", "install", "PyPDF2"])
        from PyPDF2 import PdfReader
    except Exception as e:
        print(f"Houve um erro ao tentar instalar o PyPDF2: {e}")
```